### PR TITLE
fix for Qt 5.10, 5.11

### DIFF
--- a/bin/extract-qt-installer
+++ b/bin/extract-qt-installer
@@ -124,12 +124,16 @@ var status = {
 }
 
 function tryFinish() {
-
 	if (status.finishedPageVisible && status.installationFinished) {
-		if (status.widget.RunItCheckBox) {
-			status.widget.RunItCheckBox.setChecked(false);
-		}
-		log("Press Finish Button");
+        if (status.widget.LaunchQtCreatorCheckBoxForm) {
+            // Disable this checkbox for minimal platform
+            status.widget.LaunchQtCreatorCheckBoxForm.launchQtCreatorCheckBox.setChecked(false);
+        }
+        if (status.widget.RunItCheckBox) {
+            // LaunchQtCreatorCheckBoxForm may not work for newer versions.
+            status.widget.RunItCheckBox.setChecked(false);
+        }
+        log("Press Finish Button");
 	    gui.clickButton(buttons.FinishButton);
 	}
 }
@@ -248,7 +252,11 @@ Controller.prototype.LicenseAgreementPageCallback = function() {
 
 Controller.prototype.ReadyForInstallationPageCallback = function() {
     log("Ready to install");
-    gui.clickButton(buttons.CommitButton);
+
+    // Bug? If commit button pressed too quickly finished callback might not show the checkbox to disable running qt creator
+    // Behaviour started around 5.10. You don't actually have to press this button at all with those versions, even though gui.isButtonEnabled() returns true.
+    
+    gui.clickButton(buttons.CommitButton, 200);
 }
 
 Controller.prototype.PerformInstallationPageCallback = function() {
@@ -260,16 +268,6 @@ Controller.prototype.FinishedPageCallback = function() {
     log("FinishedPageCallback");
 
     var widget = gui.currentPageWidget();
-
-    if (widget.LaunchQtCreatorCheckBoxForm) {
-        // No this form for minimal platform
-        widget.LaunchQtCreatorCheckBoxForm.launchQtCreatorCheckBox.setChecked(false);
-    }
-    
-    if (widget.RunItCheckBox) {
-		// LaunchQtCreatorCheckBoxForm may not works for newer version.
-		widget.RunItCheckBox.setChecked(false);
-	}
 
 	// Bug? Qt 5.9.5 and Qt 5.9.6 installer show finished page before the installation completed
 	// Don't press "finishButton" immediately


### PR DESCRIPTION
Qt 5.10 doesn't work right now, as it tries to open Qt Creator after installation and deadlocks in a headless environment (platform=minimal)

see #12