### PR TITLE
allow macOS installs without Xcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       - QT_CI_PACKAGES=qt.qt5.598.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.9.8 && source qt-5.9.8.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.9.8"
   - os: osx
     script: 
-      - QT_CI_PACKAGES=qt.qt5.5123.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.3 && source qt-5.12.3.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.3"
+      - QT_CI_PACKAGES=qt.qt5.5124.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.4 && source qt-5.12.4.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.4"
   - script:
     - QT_CI_PACKAGES=qt.56.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.6.0 && source qt-5.6.0.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.6.0"
   - script:
@@ -70,3 +70,5 @@ matrix:
     - QT_CI_PACKAGES=qt.qt5.5122.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.2 && source qt-5.12.2.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.2"
   - script:
     - QT_CI_PACKAGES=qt.qt5.5123.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.3 && source qt-5.12.3.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.3"
+  - script:
+    - QT_CI_PACKAGES=qt.qt5.5124.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.4 && source qt-5.12.4.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ matrix:
         - androiddeployqt --output $WORKDIR/build
   - os: osx
     script: 
-      - QT_CI_PACKAGES=qt.qt5.597.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.9.7 && source qt-5.9.7.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.9.7"
+      - QT_CI_PACKAGES=qt.qt5.598.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.9.8 && source qt-5.9.8.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.9.8"
   - os: osx
     script: 
-      - QT_CI_PACKAGES=qt.qt5.5120.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.0 && source qt-5.12.0.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.0"
+      - QT_CI_PACKAGES=qt.qt5.5123.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.3 && source qt-5.12.3.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.3"
   - script:
     - QT_CI_PACKAGES=qt.56.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.6.0 && source qt-5.6.0.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.6.0"
   - script:
@@ -61,4 +61,12 @@ matrix:
   - script:
     - QT_CI_PACKAGES=qt.qt5.597.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.9.7 && source qt-5.9.7.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.9.7"
   - script:
+    - QT_CI_PACKAGES=qt.qt5.598.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.9.8 && source qt-5.9.8.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.9.8"
+  - script:
     - QT_CI_PACKAGES=qt.qt5.5120.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.0 && source qt-5.12.0.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.0"
+  - script:
+    - QT_CI_PACKAGES=qt.qt5.5121.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.1 && source qt-5.12.1.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.1"
+  - script:
+    - QT_CI_PACKAGES=qt.qt5.5122.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.2 && source qt-5.12.2.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.2"
+  - script:
+    - QT_CI_PACKAGES=qt.qt5.5123.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.3 && source qt-5.12.3.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.3"

--- a/bin/extract-qt-installer
+++ b/bin/extract-qt-installer
@@ -143,6 +143,7 @@ function Controller() {
     });
     installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
     installer.setMessageBoxAutomaticAnswer("installationErrorWithRetry", QMessageBox.Ignore);
+    installer.setMessageBoxAutomaticAnswer("XcodeError", QMessageBox.Ok);
     
     // Allow to cancel installation for arguments --list-packages
     installer.setMessageBoxAutomaticAnswer("cancelInstallation", QMessageBox.Yes);


### PR DESCRIPTION
1. Fix installer hang on macOS when Xcode isn't installed.  This is a useful configuration when the command line tools are installed but Xcode is not.

2. Update regression for recent Qt releases.