### PR TITLE
Dehardcoded APK paths

### DIFF
--- a/bin/build-android-gradle-project
+++ b/bin/build-android-gradle-project
@@ -15,6 +15,8 @@ JARSIGNER=`which jarsigner`
 
 PRO=$1
 
+SPEC="${SPEC:-android-g++}"
+
 if [ -z "$QMAKE"]
 then
 
@@ -53,7 +55,7 @@ then
 fi
 
 set -v
-$QMAKE $PRO -r -spec android-g++
+$QMAKE $PRO -r -spec $SPEC
 
 ANDROID_BUILD_PATH=`pwd`/android-build
 
@@ -63,16 +65,6 @@ make install INSTALL_ROOT=${ANDROID_BUILD_PATH}
 
 androiddeployqt --verbose --input $JSON --output `pwd`/android-build --deployment bundled --android-platform android-${ANDROID_TARGET_SDK_VERSION} --gradle --no-gdbserver $DEPLOY_ARGS
 
-APK=${ANDROID_BUILD_PATH}/build/outputs/apk/android-build-release-signed.apk
+set -x # print signing commands which include APK name
+find ${ANDROID_BUILD_PATH}/build/outputs/apk -name "*.apk" | xargs -n 1 $JARSIGNER -verify -verbose -certs $APK
 
-if [ ! -f $APK ]
-then
-APK=${ANDROID_BUILD_PATH}/build/outputs/apk/android-build-debug.apk
-fi
-
-echo "Output APK: $APK"
-
-if [ ! -z "$JARSIGNER" ]
-then 
-     $JARSIGNER -verify -verbose -certs $APK
-fi


### PR DESCRIPTION
This hopefully makes the APK detection a bit more stable.
However, it required the commands `find` and `xargs`. Those are part of
findutils and are mostly available.