### PR TITLE
repackage Qt installer script code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
         - cat /etc/apt/sources.list
         - sudo apt-get update
         - sudo apt-get install --force-yes -qq p7zip openjdk-7-jdk ant lib32z1-dev lib32stdc++6  #lib32* are needed by Android SDK
+        - sudo apt-get install libxkbcommon-x11-0  # qt installers 2/2020
         - sudo update-alternatives --display java
         - sudo update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
         - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,24 @@ matrix:
         - qmake
         - make install INSTALL_ROOT=$WORKDIR/build
         - androiddeployqt --output $WORKDIR/build
+  - os: windows
+    language: shell
+    install:
+      wget -nv -c https://download.qt.io/archive/qt/5.12/5.12.5/qt-opensource-windows-x86-5.12.5.exe
+    script:
+      ./qt-opensource-windows-x86-5.12.5.exe --verbose --script bin/qt-install.qs QTCI_OUTPUT=${PWD}/Qt QTCI_PACKAGES=qt.qt5.5125.win32_msvc2017 && ${PWD}/Qt/5.12.5/msvc2017/bin/qmake -version && test "$(${PWD}/Qt/5.12.5/msvc2017/bin/qmake -query QT_VERSION)" = "5.12.5"
+  - os: windows
+    language: shell
+    install:
+      wget -nv -c http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe
+    script:
+      ./qt-unified-windows-x86-online.exe --verbose --script bin/qt-install.qs QTCI_OUTPUT=${PWD}/Qt QTCI_PACKAGES=qt.qt5.5125.win32_msvc2017 && ${PWD}/Qt/5.12.5/msvc2017/bin/qmake -version && test "$(${PWD}/Qt/5.12.5/msvc2017/bin/qmake -query QT_VERSION)" = "5.12.5"
   - os: osx
     script: 
       - QT_CI_PACKAGES=qt.qt5.598.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.9.8 && source qt-5.9.8.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.9.8"
   - os: osx
     script: 
-      - QT_CI_PACKAGES=qt.qt5.5124.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.4 && source qt-5.12.4.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.4"
+      - QT_CI_PACKAGES=qt.qt5.5125.clang_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.5 && source qt-5.12.5.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.5"
   - script:
     - QT_CI_PACKAGES=qt.56.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.6.0 && source qt-5.6.0.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.6.0"
   - script:
@@ -72,3 +84,5 @@ matrix:
     - QT_CI_PACKAGES=qt.qt5.5123.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.3 && source qt-5.12.3.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.3"
   - script:
     - QT_CI_PACKAGES=qt.qt5.5124.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.4 && source qt-5.12.4.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.4"
+  - script:
+    - QT_CI_PACKAGES=qt.qt5.5125.gcc_64 PATH=${TRAVIS_BUILD_DIR}/recipes:${TRAVIS_BUILD_DIR}/bin:${PATH} install-qt 5.12.5 && source qt-5.12.5.env && qmake -version && test "$(qmake -query QT_VERSION)" = "5.12.5"

--- a/bin/extract-qt-installer
+++ b/bin/extract-qt-installer
@@ -46,7 +46,7 @@ export PATH=$PATH:$PWD
 export WORKDIR=$PWD
 INSTALLER=$1
 OUTPUT=$2
-SCRIPT="$(mktemp /tmp/tmp.XXXXXXXXX)"
+SCRIPT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/qt-install.qs
 PACKAGES=$QT_CI_PACKAGES
 
 if [ $LIST_PACKAGES -gt 0 ]
@@ -74,250 +74,11 @@ else
     
 fi
 
-cat <<EOF > $SCRIPT
-
-function abortInstaller()
-{
-    installer.setDefaultPageVisible(QInstaller.Introduction, false);
-    installer.setDefaultPageVisible(QInstaller.TargetDirectory, false);
-    installer.setDefaultPageVisible(QInstaller.ComponentSelection, false);
-    installer.setDefaultPageVisible(QInstaller.ReadyForInstallation, false);
-    installer.setDefaultPageVisible(QInstaller.StartMenuSelection, false);
-    installer.setDefaultPageVisible(QInstaller.PerformInstallation, false);
-    installer.setDefaultPageVisible(QInstaller.LicenseCheck, false);
-
-    var abortText = "<font color='red' size=3>" + qsTr("Installation failed:") + "</font>";
-
-    var error_list = installer.value("component_errors").split(";;;");
-    abortText += "<ul>";
-    // ignore the first empty one
-    for (var i = 0; i < error_list.length; ++i) {
-        if (error_list[i] !== "") {
-            log(error_list[i]);
-            abortText += "<li>" + error_list[i] + "</li>"
-        }
-    }
-    abortText += "</ul>";
-    installer.setValue("FinishedText", abortText);
-}
-
-function log() {
-    var msg = ["QTCI: "].concat([].slice.call(arguments));
-    console.log(msg.join(" "));
-}
-
-function printObject(object) {
-	var lines = [];
-	for (var i in object) {
-		lines.push([i, object[i]].join(" "));
-	}
-	log(lines.join(","));
-}
-
-var status = {
-	widget: null,
-	finishedPageVisible: false,
-	installationFinished: false
-}
-
-function tryFinish() {
-	if (status.finishedPageVisible && status.installationFinished) {
-        if (status.widget.LaunchQtCreatorCheckBoxForm) {
-            // Disable this checkbox for minimal platform
-            status.widget.LaunchQtCreatorCheckBoxForm.launchQtCreatorCheckBox.setChecked(false);
-        }
-        if (status.widget.RunItCheckBox) {
-            // LaunchQtCreatorCheckBoxForm may not work for newer versions.
-            status.widget.RunItCheckBox.setChecked(false);
-        }
-        log("Press Finish Button");
-	    gui.clickButton(buttons.FinishButton);
-	}
-}
-
-function Controller() {
-    installer.installationFinished.connect(function() {
-		status.installationFinished = true;
-        gui.clickButton(buttons.NextButton);
-        tryFinish();
-    });
-    installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
-    installer.setMessageBoxAutomaticAnswer("installationErrorWithRetry", QMessageBox.Ignore);
-    installer.setMessageBoxAutomaticAnswer("XcodeError", QMessageBox.Ok);
-    
-    // Allow to cancel installation for arguments --list-packages
-    installer.setMessageBoxAutomaticAnswer("cancelInstallation", QMessageBox.Yes);
-}
-
-Controller.prototype.WelcomePageCallback = function() {
-    log("Welcome Page");
-
-    gui.clickButton(buttons.NextButton);
-
-    var widget = gui.currentPageWidget();
-
-	/* 
-	   Online installer 3.0.6 
-	   - It must disconnect the completeChanged callback after used, otherwise it will click the 'next' button on another pages
-	 */
-    var callback = function() {
-        gui.clickButton(buttons.NextButton);
-        widget.completeChanged.disconnect(callback);
-	}
-
-    widget.completeChanged.connect(callback);
-}
-
-Controller.prototype.CredentialsPageCallback = function() {
-	
-	var login = installer.environmentVariable("QT_CI_LOGIN");
-	var password = installer.environmentVariable("QT_CI_PASSWORD");
-
-	if (login === "" || password === "") {
-		gui.clickButton(buttons.CommitButton);
-	}
-	
-    var widget = gui.currentPageWidget();
-
-	widget.loginWidget.EmailLineEdit.setText(login);
-
-	widget.loginWidget.PasswordLineEdit.setText(password);
-
-    gui.clickButton(buttons.CommitButton);
-}
-
-Controller.prototype.ComponentSelectionPageCallback = function() {
-    log("ComponentSelectionPageCallback");
-
-    function list_packages() {
-      var components = installer.components();
-      log("Available components: " + components.length);
-      var packages = ["Packages: "];
-
-      for (var i = 0 ; i < components.length ;i++) {
-          packages.push(components[i].name);
-      }
-      log(packages.join(" "));
-    }
-      
-    if ($LIST_PACKAGES) {
-        list_packages();
-        gui.clickButton(buttons.CancelButton);
-        return;
-    }
-
-    log("Select components");
-
-    function trim(str) {
-        return str.replace(/^ +/,"").replace(/ *$/,"");
-    }
-
-    var widget = gui.currentPageWidget();
-
-    var packages = trim("$PACKAGES").split(",");
-    if (packages.length > 0 && packages[0] !== "") {
-        widget.deselectAll();
-        var components = installer.components();
-        var allfound = true;
-        for (var i in packages) {
-            var pkg = trim(packages[i]);
-            var found = false;
-            for (var j in components) {
-                if (components[j].name === pkg) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                allfound = false;
-                log("ERROR: Package " + pkg + " not found.");
-            } else {
-                log("Select " + pkg);
-                widget.selectComponent(pkg);
-            }
-        }
-        if (!allfound) {
-            list_packages();
-            // TODO: figure out how to set non-zero exit status.
-            gui.clickButton(buttons.CancelButton);
-            return;
-        }
-    } else {
-       log("Use default component list");
-    }
-
-    gui.clickButton(buttons.NextButton);
-}
-
-Controller.prototype.IntroductionPageCallback = function() {
-    log("Introduction Page");
-    log("Retrieving meta information from remote repository");
-    
-   	/* 
-	   Online installer 3.0.6 
-	   - Don't click buttons.NextButton directly. It will skip the componenet selection.
-    */
-    
-	if (installer.isOfflineOnly()) {
-		gui.clickButton(buttons.NextButton);
-	}  
-}
-
-Controller.prototype.TargetDirectoryPageCallback = function() {
-    log("Set target installation page: $OUTPUT");
-    var widget = gui.currentPageWidget();
-
-    if (widget != null) {
-        widget.TargetDirectoryLineEdit.setText("$OUTPUT");
-    }
-    
-    gui.clickButton(buttons.NextButton);
-}
-
-Controller.prototype.LicenseAgreementPageCallback = function() {
-    log("Accept license agreement");
-    var widget = gui.currentPageWidget();
-
-    if (widget != null) {
-        widget.AcceptLicenseRadioButton.setChecked(true);
-    }
-
-    gui.clickButton(buttons.NextButton);
-}
-
-Controller.prototype.ReadyForInstallationPageCallback = function() {
-    log("Ready to install");
-
-    // Bug? If commit button pressed too quickly finished callback might not show the checkbox to disable running qt creator
-    // Behaviour started around 5.10. You don't actually have to press this button at all with those versions, even though gui.isButtonEnabled() returns true.
-    
-    gui.clickButton(buttons.CommitButton, 200);
-}
-
-Controller.prototype.PerformInstallationPageCallback = function() {
-    log("PerformInstallationPageCallback");
-    gui.clickButton(buttons.CommitButton);
-}
-
-Controller.prototype.FinishedPageCallback = function() {
-    log("FinishedPageCallback");
-
-    var widget = gui.currentPageWidget();
-
-	// Bug? Qt 5.9.5 and Qt 5.9.6 installer show finished page before the installation completed
-	// Don't press "finishButton" immediately
-    
-	status.finishedPageVisible = true;
-	status.widget = widget;
-	tryFinish();   
-}
-
-EOF
 
 chmod u+x $1
 if [ -n "$QT_CI_DEBUG" ] 
 then
-	$INSTALLER -v --script $SCRIPT | grep "\(QTCI\|operation\)"
+	$INSTALLER -v --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT" | grep "\(QTCI\|operation\)"
 	exit 0
 fi
 
@@ -325,15 +86,15 @@ unset DISPLAY
 
 if [ -n "$DISABLE_PROGRESS_REPORT" ]
 then
-	QT_QPA_PLATFORM=minimal $INSTALLER --script $SCRIPT 
+	QT_QPA_PLATFORM=minimal $INSTALLER --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT" 
 else
 	ARGS="-v"
 
 	if [ -n "$VERBOSE" ]
 	then
-		QT_QPA_PLATFORM=minimal $INSTALLER $ARGS --script $SCRIPT
+		QT_QPA_PLATFORM=minimal $INSTALLER $ARGS --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT"
 	else
-		QT_QPA_PLATFORM=minimal $INSTALLER $ARGS --script $SCRIPT | grep "\(QTCI\|operation\)"
+		QT_QPA_PLATFORM=minimal $INSTALLER $ARGS --script $SCRIPT QTCI_LIST_PACKAGES="$LIST_PACKAGES" QTCI_PACKAGES="$PACKAGES" QTCI_OUTPUT="$OUTPUT" | grep "\(QTCI\|operation\)"
 	fi
 fi
 

--- a/bin/qt-install.qs
+++ b/bin/qt-install.qs
@@ -101,6 +101,24 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
         log(packages.join(" "));
     }
 
+    var widget = gui.currentPageWidget();
+
+    var archiveCheckBox = gui.findChild(widget, "Archive");
+    var latestCheckBox = gui.findChild(widget, "Latest releases");
+    var fetchButton = gui.findChild(widget, "FetchCategoryButton");
+
+    if (archiveCheckBox != null) {
+      // check archive
+      archiveCheckBox.click();
+    }
+    if (latestCheckBox != null) {
+      // uncheck latest
+      latestCheckBox.click();
+    }
+    if (fetchButton != null) {
+      fetchButton.click()
+    }
+
     if (installer.value("QTCI_LIST_PACKAGES", "0") != "0") {
         list_packages();
         gui.clickButton(buttons.CancelButton);
@@ -112,8 +130,6 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     function trim(str) {
         return str.replace(/^ +/, "").replace(/ *$/, "");
     }
-
-    var widget = gui.currentPageWidget();
 
     var packages = trim(installer.value("QTCI_PACKAGES")).split(",");
     if (packages.length > 0 && packages[0] !== "") {

--- a/bin/qt-install.qs
+++ b/bin/qt-install.qs
@@ -225,4 +225,16 @@ Controller.prototype.DynamicTelemetryPluginFormCallback = function()
 Controller.prototype.StartMenuDirectoryPageCallback = function() {
     log("StartMenuDirectoryPageCallback");
     gui.clickButton(buttons.NextButton);
-};
+}
+
+// qt online installer 3.2.1: open source users must now accept the open
+// source obligations.
+// https://www.qt.io/blog/qt-online-installer-3.2.1-released
+Controller.prototype.ObligationsPageCallback = function()
+{
+    log("ObligationsPageCallback");
+    var page = gui.pageWidgetByObjectName("ObligationsPage");
+    page.obligationsAgreement.setChecked(true);
+    page.completeChanged();
+    gui.clickButton(buttons.NextButton);
+}

--- a/bin/qt-install.qs
+++ b/bin/qt-install.qs
@@ -1,0 +1,228 @@
+// QT-CI Project
+// License: Apache-2.0
+// https://github.com/benlau/qtci
+
+function log() {
+    var msg = ["QTCI: "].concat([].slice.call(arguments));
+    console.log(msg.join(" "));
+}
+
+function printObject(object) {
+    var lines = [];
+    for (var i in object) {
+        lines.push([i, object[i]].join(" "));
+    }
+    log(lines.join(","));
+}
+
+var status = {
+    widget: null,
+    finishedPageVisible: false,
+    installationFinished: false
+}
+
+function tryFinish() {
+    if (status.finishedPageVisible && status.installationFinished) {
+        if (status.widget.LaunchQtCreatorCheckBoxForm) {
+            // Disable this checkbox for minimal platform
+            status.widget.LaunchQtCreatorCheckBoxForm.launchQtCreatorCheckBox.setChecked(false);
+        }
+        if (status.widget.RunItCheckBox) {
+            // LaunchQtCreatorCheckBoxForm may not work for newer versions.
+            status.widget.RunItCheckBox.setChecked(false);
+        }
+        log("Press Finish Button");
+        gui.clickButton(buttons.FinishButton);
+    }
+}
+
+function Controller() {
+    installer.installationFinished.connect(function() {
+        status.installationFinished = true;
+        gui.clickButton(buttons.NextButton);
+        tryFinish();
+    });
+    installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
+    installer.setMessageBoxAutomaticAnswer("installationErrorWithRetry", QMessageBox.Ignore);
+    installer.setMessageBoxAutomaticAnswer("XcodeError", QMessageBox.Ok);
+
+    // Allow to cancel installation for arguments --list-packages
+    installer.setMessageBoxAutomaticAnswer("cancelInstallation", QMessageBox.Yes);
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    log("Welcome Page");
+
+    gui.clickButton(buttons.NextButton);
+
+    var widget = gui.currentPageWidget();
+
+    /* 
+	   Online installer 3.0.6 
+	   - It must disconnect the completeChanged callback after used, otherwise it will click the 'next' button on another pages
+	 */
+    var callback = function() {
+        gui.clickButton(buttons.NextButton);
+        widget.completeChanged.disconnect(callback);
+    }
+
+    widget.completeChanged.connect(callback);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+
+    var login = installer.environmentVariable("QT_CI_LOGIN");
+    var password = installer.environmentVariable("QT_CI_PASSWORD");
+
+    if (login === "" || password === "") {
+        gui.clickButton(buttons.CommitButton);
+    }
+
+    var widget = gui.currentPageWidget();
+
+    widget.loginWidget.EmailLineEdit.setText(login);
+
+    widget.loginWidget.PasswordLineEdit.setText(password);
+
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    log("ComponentSelectionPageCallback");
+
+    function list_packages() {
+        var components = installer.components();
+        log("Available components: " + components.length);
+        var packages = ["Packages: "];
+
+        for (var i = 0; i < components.length; i++) {
+            packages.push(components[i].name);
+        }
+        log(packages.join(" "));
+    }
+
+    if (installer.value("QTCI_LIST_PACKAGES", "0") != "0") {
+        list_packages();
+        gui.clickButton(buttons.CancelButton);
+        return;
+    }
+
+    log("Select components");
+
+    function trim(str) {
+        return str.replace(/^ +/, "").replace(/ *$/, "");
+    }
+
+    var widget = gui.currentPageWidget();
+
+    var packages = trim(installer.value("QTCI_PACKAGES")).split(",");
+    if (packages.length > 0 && packages[0] !== "") {
+        widget.deselectAll();
+        var components = installer.components();
+        var allfound = true;
+        for (var i in packages) {
+            var pkg = trim(packages[i]);
+            var found = false;
+            for (var j in components) {
+                if (components[j].name === pkg) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                allfound = false;
+                log("ERROR: Package " + pkg + " not found.");
+            } else {
+                log("Select " + pkg);
+                widget.selectComponent(pkg);
+            }
+        }
+        if (!allfound) {
+            list_packages();
+            // TODO: figure out how to set non-zero exit status.
+            gui.clickButton(buttons.CancelButton);
+            return;
+        }
+    } else {
+        log("Use default component list");
+    }
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    log("Introduction Page");
+    log("Retrieving meta information from remote repository");
+
+    /* 
+	   Online installer 3.0.6 
+	   - Don't click buttons.NextButton directly. It will skip the componenet selection.
+    */
+
+    if (installer.isOfflineOnly()) {
+        gui.clickButton(buttons.NextButton);
+    }
+}
+
+Controller.prototype.TargetDirectoryPageCallback = function() {
+    var output = installer.value("QTCI_OUTPUT");
+    log("Set target installation page: " + output);
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.TargetDirectoryLineEdit.setText(output);
+    }
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    log("Accept license agreement");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.AcceptLicenseRadioButton.setChecked(true);
+    }
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function() {
+    log("Ready to install");
+
+    // Bug? If commit button pressed too quickly finished callback might not show the checkbox to disable running qt creator
+    // Behaviour started around 5.10. You don't actually have to press this button at all with those versions, even though gui.isButtonEnabled() returns true.
+    gui.clickButton(buttons.CommitButton, 200);
+}
+
+Controller.prototype.PerformInstallationPageCallback = function() {
+    log("PerformInstallationPageCallback");
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+    log("FinishedPageCallback");
+
+    var widget = gui.currentPageWidget();
+
+    // Bug? Qt 5.9.5 and Qt 5.9.6 installer show finished page before the installation completed
+    // Don't press "finishButton" immediately
+    status.finishedPageVisible = true;
+    status.widget = widget;
+    tryFinish();
+}
+
+// Telemetry disabled 
+Controller.prototype.DynamicTelemetryPluginFormCallback = function()
+{
+    log("TelemetryPluginFormCallback");
+    var page = gui.pageWidgetByObjectName("DynamicTelemetryPluginForm");
+    page.statisticGroupBox.disableStatisticRadioButton.setChecked(true);
+    gui.clickButton(buttons.NextButton);
+}
+
+// On windows installs there is a page about the start menu.
+Controller.prototype.StartMenuDirectoryPageCallback = function() {
+    log("StartMenuDirectoryPageCallback");
+    gui.clickButton(buttons.NextButton);
+};

--- a/recipes/install-qt-online
+++ b/recipes/install-qt-online
@@ -17,12 +17,23 @@ fi
 export QT_CI_PACKAGES=${1}
 QT_TARGET_CATALOG=${2:-$PWD}
 QT_CI_DOWNLOADER=${QT_CI_DOWNLOADER:-"wget -c -N"}
+INSTALLER_VERSION=latest
+# or a triplet like
+#INSTALLER_VERSION=3.0.6
 
 if [ "$(uname)" = "Darwin" ]; then
-  DOWNLOAD_URL=https://download.qt.io/archive/online_installers/3.0/qt-unified-mac-x64-3.0.6-online.dmg
+  if [ "${INSTALLER_VERSION}" = "latest" ]; then
+    DOWNLOAD_URL=https://download.qt.io/official_releases/online_installers/qt-unified-mac-x64-online.dmg
+  else
+    DOWNLOAD_URL=https://download.qt.io/archive/online_installers/$(echo ${INSTALLER_VERSION} | cut -d . -f1-2)/qt-unified-mac-x64-${INSTALLER_VERSION}-online.dmg
+  fi
   COMPILER=clang_64
 elif [ "$(uname)" = "Linux" ]; then
-  DOWNLOAD_URL=https://download.qt.io/archive/online_installers/3.0/qt-unified-linux-x64-3.0.6-online.run
+  if [ "${INSTALLER_VERSION}" = "latest" ]; then
+    DOWNLOAD_URL=https://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run
+  else
+    DOWNLOAD_URL=https://download.qt.io/archive/online_installers/$(echo ${INSTALLER_VERSION} | cut -d . -f1-2)/qt-unified-linux-x64-${INSTALLER_VERSION}-online.run
+  fi
   COMPILER=gcc_64
 else
   echo "Unsupported system." >&2
@@ -30,7 +41,6 @@ else
 fi
 
 INSTALLER=$(basename $DOWNLOAD_URL)
-ENVFILE=${QT_TARGET_CATALOG}/qt-${QT_VERSION}.env
 
 echo Downloading Qt
 ${QT_CI_DOWNLOADER} ${DOWNLOAD_URL} || exit 1

--- a/recipes/install-qt-online
+++ b/recipes/install-qt-online
@@ -3,23 +3,24 @@
 
 function usage() {
     echo "Usage:"
-    echo "install-qt-online \"packages\" output_path"
-    echo "Example"
-    echo "install-qt-online 'qt.qt5.5121.gcc_64' /opt/Qt"
+    echo "install-qt-online \"packages\" [output_path [qt_installer_version]]"
+    echo "Examples:"
+    echo "install-qt-online \"qt.qt5.5121.gcc_64\""
+    echo "install-qt-online \"qt.qt5.5121.gcc_64\" /opt/Qt"
+    echo "install-qt-online \"qt.qt5.5121.gcc_64\" /opt/Qt latest"
+    echo "install-qt-online \"qt.qt5.5121.gcc_64\" /opt/Qt 3.1.1"
     exit -1
 }
 
-if [ $# -lt 2 ]
+if [ $# -lt 1 ]
 then
 	usage
 fi
 
 export QT_CI_PACKAGES=${1}
 QT_TARGET_CATALOG=${2:-$PWD}
+INSTALLER_VERSION=${3:-latest} # lastest or a version triplet, e.g. 3.1.1
 QT_CI_DOWNLOADER=${QT_CI_DOWNLOADER:-"wget -c -N"}
-INSTALLER_VERSION=latest
-# or a triplet like
-#INSTALLER_VERSION=3.0.6
 
 if [ "$(uname)" = "Darwin" ]; then
   if [ "${INSTALLER_VERSION}" = "latest" ]; then
@@ -48,12 +49,14 @@ ${QT_CI_DOWNLOADER} ${DOWNLOAD_URL} || exit 1
 echo Installing Qt
 
 if [ "$(uname)" = "Darwin" ]; then
-  INSTALLER_NAME=${INSTALLER%.*}
-  APPFILE=/Volumes/${INSTALLER_NAME}/${INSTALLER_NAME}.app/Contents/MacOS/${INSTALLER_NAME}
-  hdiutil attach ${PWD}/${INSTALLER}
-  extract-qt-installer $APPFILE ${QT_TARGET_CATALOG}/Qt
-  hdiutil detach /Volumes/${INSTALLER_NAME}
+  hdiutil attach ${PWD}/${INSTALLER} -plist > minfo.plist
+  MOUNTPOINT=$(/usr/libexec/PlistBuddy -c "Print :system-entities:0:mount-point" minfo.plist || \
+               /usr/libexec/PlistBuddy -c "Print :system-entities:1:mount-point" minfo.plist || \
+               /usr/libexec/PlistBuddy -c "Print :system-entities:2:mount-point" minfo.plist)
+  INSTALLER_NAME=$(basename "${MOUNTPOINT}")
+  APPFILE="${MOUNTPOINT}"/${INSTALLER_NAME}.app/Contents/MacOS/${INSTALLER_NAME}
+  extract-qt-installer "$APPFILE" "${QT_TARGET_CATALOG}/Qt"
+  hdiutil detach "${MOUNTPOINT}"
 elif [ "$(uname)" = "Linux" ]; then
-  extract-qt-installer ${PWD}/${INSTALLER} ${QT_TARGET_CATALOG}/Qt
+  extract-qt-installer ${PWD}/${INSTALLER} "${QT_TARGET_CATALOG}/Qt"
 fi
-


### PR DESCRIPTION
The separation of the bash shell code and the Qt Installer script
code allows the later to be used in environments were bash is not
available.  This was implemented with key,value pairs passed on
the command line, but it could have been done with environmental
variables using the installer environmentVariable method instead
of the value method.

add Qt 5.12.5 to regression.

add windows test cases to regression.  You can see how the installer script
code can be passed directly to the installer.  Even though the travis test case uses bash
in the yml file the separation of the script allows the installer and script to be used when bash isn't available.

add support for installs on windows, which have a unique page, see Controller.prototype.StartMenuDirectoryPageCallback

add support for new usage stats page, see Controller.prototype.DynamicTelemetryPluginFormCallback.
Recent installs with the online installer would fail due to this new page.
See https://www.qt.io/blog/option-to-provide-anonymous-usage-statistics-enabled.

Delete unused function in Qt installer script (abortInstaller).